### PR TITLE
fix: pypi_publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,15 +36,15 @@ jobs:
       run: |  
         python -m poetry build
 
-    - name: Publish package on Test PyPi
-      uses: pypa/gh-action-pypi-publish@v1
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
         password: ${{ secrets.PYPI_TEST_API_TOKEN }}
-        repository-url: https://test.pypi.org/legacy
+        repository-url: https://test.pypi.org/legacy/
 
-    - name: Publish package on PyPi
-      uses: pypa/gh-action-pypi-publish@v1
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Description
fixed: pypa/gh-action-pypi-publish to use master version instead of v1

## Checklist
#### PR Submitter
- [x] I have thought about how this code may affect other services.
- [x] This code is better than I found it.

#### Reviewer
- [x] I understand that approving this code, I am also responsible for it going into the codebase.
